### PR TITLE
Update repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Quramy",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Quramy/graphql-decorator.git"
+    "url": "https://github.com/indigotech/graphql-decorator.git"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
It was quite hard to find this fork over the Internet.
I found this package on [npmjs.com](https://www.npmjs.com/package/graphql-schema-decorator) but the page points to wrong repository.
Let's fix that.