### PR TITLE
Bugfix - Explicit type assertion

### DIFF
--- a/src/object_type_factory.spec.ts
+++ b/src/object_type_factory.spec.ts
@@ -50,13 +50,26 @@ describe('objectTypeFactory', function() {
         assert(GQLType._typeConfig.name === 'Obj');
     });
 
-      it('returns GraphQLInputObjectType with a class annotated by nested @InputObjectType objects', function() {
-        @D.InputObjectType()
-        class Nested { @D.Field() title: string; }
+    it('returns GraphQLInputObjectType with a class annotated by nested @InputObjectType objects', function() {
+      @D.InputObjectType()
+      class Nested { @D.Field() title: string; }
 
-        @D.InputObjectType()
-        class Obj { @D.Field() title: string; @D.Field({type: Nested }) nested: Nested; }
+      @D.InputObjectType()
+      class Obj { @D.Field() title: string; @D.Field({type: Nested }) nested: Nested; }
+      const GQLType = objectTypeFactory(Obj, true);
+      assert(GQLType._typeConfig.name === 'Obj');
+    });
+
+    it('raises exception if nested @InputObjectType is undefined', function() {
+      // this can be caused when order of `import` is messed up and/or nested type can not be infered
+      @D.InputObjectType()
+      class Obj { @D.Field() title: string; @D.Field({type: undefined }) nested: {}; }
+      try {
         const GQLType = objectTypeFactory(Obj, true);
-        assert(GQLType._typeConfig.name === 'Obj');
+        assert.fail();
+      } catch (e) {
+          const err = e as SchemaFactoryError;
+          assert(err.type === SchemaFactoryErrorType.NO_FIELD);
+        }
     });
 });

--- a/src/object_type_factory.ts
+++ b/src/object_type_factory.ts
@@ -29,7 +29,12 @@ export function objectTypeFactory(target: Function, isInput?: boolean) {
     const fieldMetadataList = Reflect.getMetadata(GQ_FIELDS_KEY, target.prototype) as FieldTypeMetadata[];
     const fields: {[key: string]: any} = {};
     fieldMetadataList.forEach(def => {
-        fields[def.name] = fieldTypeFactory(target, def, isInput);
+        let field = fieldTypeFactory(target, def, isInput);
+        if (!field) {
+            // tslint:disable-next-line:max-line-length
+            throw new SchemaFactoryError(`@ObjectType()'s ${def.name} is annotated by @Filed() but no type could be inferred`, SchemaFactoryErrorType.NO_FIELD);
+        }
+        fields[def.name] = field;
     });
     if (!!isInput) {
         objectTypeRepository[objectTypeMetadata.name] = new graphql.GraphQLInputObjectType({


### PR DESCRIPTION
When order of `import` is messed up and/or nested type can not be inferred, a error silent occurs without any indication of what is the problem.

This PR makes this type of assertion a little more verbose to help diagnose the issue when creating the schema with this kind of runtime problem