### PR TITLE
Proposal: Adding middleware for field schema function resolution

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -25,6 +25,7 @@ export interface TypeMetadata {
     isList?: boolean;
     isPagination?: boolean;
     explicitType?: any;
+    beforeMiddleware?: Middleware;
 }
 
 export interface ArgumentMetadata extends TypeMetadata {
@@ -78,6 +79,8 @@ export interface DescriptionMetadata {
 export interface PropertyDescriptionMetadata extends DescriptionMetadata {
     name: string;
 }
+
+export type Middleware = (context: any, args: { [key: string]: any }, next: (error?: Error, value?: any) => any) => Promise<any> | any;
 
 function mergeDescriptionMetadata(target: any, sourceMetadata: any): any {
     if (target.prototype != null && Reflect.hasMetadata(GQ_DESCRIPTION_KEY, target.prototype)) {
@@ -280,6 +283,21 @@ export function NonNull() {
             createOrSetFieldTypeMetadata(target, {
                 name: propertyKey,
                 isNonNull: true,
+            });
+        }
+    } as Function;
+}
+
+export function Before(middleware: Middleware) {
+    return function (target: any, propertyKey: any, index?: number) {
+        if (index >= 0) {
+            setArgumentMetadata(target, propertyKey, index, {
+                beforeMiddleware: middleware,
+            });
+        } else {
+            createOrSetFieldTypeMetadata(target, {
+                name: propertyKey,
+                beforeMiddleware: middleware,
             });
         }
     } as Function;

--- a/src/field_type_factory.spec.ts
+++ b/src/field_type_factory.spec.ts
@@ -60,6 +60,44 @@ describe('resolverFactory', function() {
         const actual = fn(new Obj(), {input: 1});
         assert(actual === 2);
     });
+
+    describe('Before Middleware', () => {
+
+      it('makes sure Before is executed before resolving', function(done) {
+
+        let middleware: D.Middleware = (context: any, args: { [key: string]: any }, next: (error?: Error, value?: any) => any): any => {
+          assert(true);
+          done();
+        };
+        class Obj { @D.Field() @D.Before(middleware) twice(input: number): number { console.log(input); return input * 2; } }
+        const fn = resolverFactory(Obj, 'twice', [{name: 'input'}], null, null, new Obj(), middleware).fn;
+        const actual = fn(new Obj(), {input: 1});
+      });
+
+      it('makes sure middleware can override function execution if next is called with a value', function() {
+
+        let middleware: D.Middleware = (context: any, args: { [key: string]: any }, next: (error?: Error, value?: any) => any): any => {
+          next(null, 5);
+        };
+        class Obj { @D.Field() @D.Before(middleware) twice(input: number): number { return input * 2; } }
+        const fn = resolverFactory(Obj, 'twice', [{name: 'input'}], null, null, new Obj(), middleware).fn;
+        const actual = fn(new Obj(), {input: 1});
+        assert(actual === 5);
+      });
+
+      // tslint:disable-next-line:max-line-length
+      it('makes sure middleware can override function execution if next is called with a value even if it is null (as long it ir not undefined)', function() {
+
+        let middleware: D.Middleware = (context: any, args: { [key: string]: any }, next: (error?: Error, value?: any) => any): any => {
+          next(null, null);
+        };
+        class Obj { @D.Field() @D.Before(middleware) twice(input: number): number { return input * 2; } }
+        const fn = resolverFactory(Obj, 'twice', [{name: 'input'}], null, null, new Obj(), middleware).fn;
+        const actual = fn(new Obj(), {input: 1});
+        assert(actual === null);
+      });
+    });
+
 });
 
 describe('fieldTypeFactory', function() {


### PR DESCRIPTION
Adding ability to declarative override function resolution on schemas with an implementation analog to an express middleware.

### Usage example

```typescript

import { 
  Middleware,
  Before,
  Field,
} from 'graphql-schema-decorators';

...

let middleware: Middleware = (context: any, args: { [key: string]: any }, next: (error?: Error, value?: any) => any): any => {
  if(context.user.role != 'any role') {
    // can use context and resolve value to `null`, regardless of what resolve function actually implements
    next(null, null);
  } else {
    // keeps regular resolution flow
    next();
  }
};

...

class ObjType {
  @Field() 
  @Before(middleware) 
  myFunction(input: number): number { 
    return input * 2; 
  }
}

```


### Future improvements / TODO

- Add middleware error parameter handling (What should be the expected behavior?)
- Allow middleware to be `Promise`-based