### PR TITLE
Bugfix - Order by sort column is now non nullable

### DIFF
--- a/src/order-by.type-factory.ts
+++ b/src/order-by.type-factory.ts
@@ -1,6 +1,6 @@
-import { FieldTypeMetadata , GQ_OBJECT_METADATA_KEY , GQ_FIELDS_KEY , ObjectTypeMetadata } from './decorator';
-import { SchemaFactoryError , SchemaFactoryErrorType } from './schema_factory';
-import { GraphQLInputObjectType, GraphQLInputObjectTypeConfig, GraphQLList, GraphQLEnumType } from 'graphql';
+import { FieldTypeMetadata, GQ_FIELDS_KEY, GQ_OBJECT_METADATA_KEY, ObjectTypeMetadata } from './decorator';
+import { GraphQLEnumType, GraphQLInputObjectType, GraphQLInputObjectTypeConfig, GraphQLList, GraphQLNonNull } from 'graphql';
+import { SchemaFactoryError, SchemaFactoryErrorType } from './schema_factory';
 
 export class OrderByTypeFactory {
 
@@ -24,7 +24,7 @@ export class OrderByTypeFactory {
       name: name + 'OrderingInputObjectType',
       description: 'Ordering object',
       fields: {
-          sort: { type: orderBySortEnumObject },
+          sort: { type: new GraphQLNonNull(orderBySortEnumObject) },
           direction: { type: orderByDirectionEnumObject },
       },
     });


### PR DESCRIPTION
`orderBy` sort column is now non nullable

Now it will error on schema validation if a query like the following is sent

```graphql
{
  MyPaginatedQuery(orderBy: [{}]) {
    anyScalarField
  }
}
```

```
Argument "orderBy" has invalid value [{}]...
```