### PR TITLE
Adding ability to add custom sort params to @OrderBy params

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -26,6 +26,7 @@ export interface TypeMetadata {
     isPagination?: boolean;
     explicitType?: any;
     beforeMiddleware?: Middleware;
+    extraParams?: any;
 }
 
 export interface ArgumentMetadata extends TypeMetadata {
@@ -369,10 +370,11 @@ export function Ctx() {
     } as Function;
 }
 
-export function OrderBy() {
+export function OrderBy(extraColumnsToSortBy: string[] = []) {
     return function (target: any, propertyKey: any, index: number) {
         setArgumentMetadata(target, propertyKey, index, {
             name: 'orderBy',
+            extraParams: extraColumnsToSortBy,
         });
     } as Function;
 }

--- a/src/object_type_factory.ts
+++ b/src/object_type_factory.ts
@@ -24,7 +24,7 @@ export function objectTypeFactory(target: Function, isInput?: boolean) {
     }
     if (!Reflect.hasMetadata(GQ_FIELDS_KEY, target.prototype)) {
         // tslint:disable-next-line:max-line-length
-        throw new SchemaFactoryError('Class annotated by @ObjectType() should has one or more fields annotated by @Filed()', SchemaFactoryErrorType.NO_FIELD);
+        throw new SchemaFactoryError('Class annotated by @ObjectType() should has one or more fields annotated by @Field()', SchemaFactoryErrorType.NO_FIELD);
     }
     const fieldMetadataList = Reflect.getMetadata(GQ_FIELDS_KEY, target.prototype) as FieldTypeMetadata[];
     const fields: {[key: string]: any} = {};
@@ -32,7 +32,7 @@ export function objectTypeFactory(target: Function, isInput?: boolean) {
         let field = fieldTypeFactory(target, def, isInput);
         if (!field) {
             // tslint:disable-next-line:max-line-length
-            throw new SchemaFactoryError(`@ObjectType()'s ${def.name} is annotated by @Filed() but no type could be inferred`, SchemaFactoryErrorType.NO_FIELD);
+            throw new SchemaFactoryError(`@ObjectType()'s ${def.name} is annotated by @Field() but no type could be inferred`, SchemaFactoryErrorType.NO_FIELD);
         }
         fields[def.name] = field;
     });

--- a/src/order-by.type-factory.ts
+++ b/src/order-by.type-factory.ts
@@ -63,6 +63,19 @@ export class OrderByTypeFactory {
                 orderByFieldArray.push(def);
             }
         });
+
+        if (metadata.args &&
+            metadata.args.length > 0) {
+
+          let sortArg = metadata.args.filter(arg => arg.name === 'orderBy')[0];
+          if ( sortArg && sortArg.extraParams && sortArg.extraParams.constructor === Array) {
+            sortArg.extraParams.filter((item: any) => item && item.constructor === String)
+            .forEach((item: string) => orderByFieldArray.push({
+              name: item,
+              description: item,
+            }));
+          }
+        }
         let orderBySortEnumObject = OrderByTypeFactory.orderByFieldEnumFactory(metadata.name, orderByFieldArray);
         let orderByDirectionEnumObject = OrderByTypeFactory.orderByDirectionEnumFactory(metadata.name);
         let orderByInputObject = OrderByTypeFactory.orderByInputObjectFactory(metadata.name, orderBySortEnumObject,


### PR DESCRIPTION
`orderBy` sort column auto-generated array now can be extended to have custom fields as pleased instead of just having the fields from returned object provided on `Field` decorator.

This is passed as an array to the `OrderBy` decorator, and all strings passed will be added as possible `sort` columns to the schema.

Example:
```
@OrderBy(['extraField']) orderBy?: OrderByItem[] // 'extraField' is added as a possible value to the sort enum
```

Also fixed some typos on error messages

