### PR TITLE
Feature - @OrderBy ignore schema fields

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -370,11 +370,11 @@ export function Ctx() {
     } as Function;
 }
 
-export function OrderBy(extraColumnsToSortBy: string[] = []) {
+export function OrderBy(params?: {extraColumns: string[], shouldIgnoreSchemaFields?: boolean } | string[]) {
     return function (target: any, propertyKey: any, index: number) {
         setArgumentMetadata(target, propertyKey, index, {
             name: 'orderBy',
-            extraParams: extraColumnsToSortBy,
+            extraParams: params.constructor === Array ? { extraColumns: params } : params,
         });
     } as Function;
 }

--- a/src/order-by.type-factory.ts
+++ b/src/order-by.type-factory.ts
@@ -68,8 +68,17 @@ export class OrderByTypeFactory {
             metadata.args.length > 0) {
 
           let sortArg = metadata.args.filter(arg => arg.name === 'orderBy')[0];
-          if ( sortArg && sortArg.extraParams && sortArg.extraParams.constructor === Array) {
-            sortArg.extraParams.filter((item: any) => item && item.constructor === String)
+          if ( sortArg &&
+              sortArg.extraParams &&
+              sortArg.extraParams.extraColumns &&
+              sortArg.extraParams.extraColumns.constructor === Array) {
+
+            if (sortArg.extraParams.shouldIgnoreSchemaFields) {
+              // remove all previous items from `orderByFieldArray`
+              orderByFieldArray.splice(0, Number.POSITIVE_INFINITY);
+            }
+
+            sortArg.extraParams.extraColumns.filter((item: any) => item && item.constructor === String)
             .forEach((item: string) => orderByFieldArray.push({
               name: item,
               description: item,


### PR DESCRIPTION
Adding ability to ignore schema fields on `@OrderBy`.

`@OrderBy` automatically adds all fields from `@Pagination` type to the generated schema sort enum. This PR adds a new param to enable ignoring them and using just the provided column names instead, adding more control to the generated schema.

Check tests for more info on what is the behavior change
