### PR TITLE
Fix type duplication issue

### DIFF
--- a/src/field_type_factory.spec.ts
+++ b/src/field_type_factory.spec.ts
@@ -1,7 +1,7 @@
 import * as D from './decorator';
 import * as graphql from 'graphql';
 
-import { fieldTypeFactory, resolverFactory } from './field_type_factory';
+import { fieldTypeFactory, resolverFactory, clearFieldTypeCache } from './field_type_factory';
 
 import { clearObjectTypeRepository } from './object_type_factory';
 
@@ -10,6 +10,7 @@ const assert = require('assert');
 describe('resolverFactory', function() {
     beforeEach(function() {
         clearObjectTypeRepository();
+        clearFieldTypeCache();
     });
 
     it('returns argumentConfigMap. The map has GraphQLInt type with a function which has number argument', function () {
@@ -101,6 +102,10 @@ describe('resolverFactory', function() {
 });
 
 describe('fieldTypeFactory', function() {
+    beforeEach(function() {
+        clearObjectTypeRepository();
+        clearFieldTypeCache();
+    });
     describe('with implicit type', function() {
         it('returns null with a class which has no field', function() {
             class Obj {}


### PR DESCRIPTION
Fixing error 

> Schema must contain unique named types but contains multiple types named _"Object type name here"_

That was raised when enums, for example, were used both `@InputObjectType` and `@ObjectType`. This PR adds a type cache by name and uses cache instead of any `new GraphQLXType()` call when resolving field decorators.

A similar problem was described at https://github.com/graphql/graphql-js/issues/146

