### PR TITLE
BugFix - @UnionType usage with abstract classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added CHANGELOG.md - #38 - [@fvasc](https://github.com/fvasc)
 - Added CI and npm badges to README - #27 - [@askmon](https://github.com/askmon)
 - Added contributing guidelines - #30 - [@askmon](https://github.com/askmon)
+- Fixed @Field arguments handling - #42 - [@felipesabino](https://github.com/felipesabino)
+- Fixed @UnionType usage with abstract classes - #43 - [@felipesabino](https://github.com/felipesabino)
 
 ### Breaking changes
 

--- a/src/metadata-builder/metadata.utils.ts
+++ b/src/metadata-builder/metadata.utils.ts
@@ -1,0 +1,43 @@
+// #kudos to @pleerock at https://github.com/typeorm/typeorm/blob/de5cfe71c7c98c1c2689855378812a38cfc051fc/src/metadata-builder/MetadataUtils.ts
+
+/**
+ * Metadata args utility functions.
+ */
+export class MetadataUtils {
+
+  /**
+   * Gets given's entity all inherited classes.
+   * Gives in order from parents to children.
+   * For example Post extends ContentModel which extends Unit it will give
+   * [Unit, ContentModel, Post]
+   */
+  static getInheritanceTree(entity: Function): Function[] {
+    const tree: Function[] = [entity];
+    const getPrototypeOf = (object: Function): void => {
+      const proto = Object.getPrototypeOf(object);
+      if (proto) {
+        tree.push(proto);
+        getPrototypeOf(proto);
+      }
+    };
+    getPrototypeOf(entity);
+    return tree;
+  }
+
+  /**
+   * Checks if this table is inherited from another table.
+   */
+  static isInherited(target1: Function, target2: Function) {
+    return target1.prototype instanceof target2;
+  }
+
+  /**
+   * Filters given array of targets by a given classes.
+   * If classes are not given, then it returns array itself.
+   */
+  static filterByTarget<T extends { target?: any }>(array: T[], classes?: any[]): T[] {
+    if (!classes) return array;
+    return array.filter(item => item.target && classes.indexOf(item.target) !== -1);
+  }
+
+}

--- a/src/specs/functional.spec.ts
+++ b/src/specs/functional.spec.ts
@@ -250,8 +250,6 @@ describe('Functional', function () {
       it('resolves @UnionType with abstact class', async function () {
         const schema = schemaFactory(SchemaType);
 
-        console.log(graphql.printSchema(schema));
-
         const result = await graphql.graphql(schema, `
         query {
           value {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,24 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "declaration": true,
-        "target": "es6",
-        "noImplicitAny": true,
-        "sourceMap": true,
-        "inlineSources": true,
-        "moduleResolution": "node",
-        "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
-        "rootDir": "src",
-        "outDir": "lib",
-        "lib": [
-            "esnext"
-        ]
-    },
-    "exclude": [
-        "node_modules",
-        "lib",
-        "examples"
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "target": "es6",
+    "noImplicitAny": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "rootDir": "src",
+    "outDir": "lib",
+    "pretty": true,
+    "lib": [
+      "esnext"
     ]
+  },
+  "exclude": [
+    "node_modules",
+    "lib",
+    "examples"
+  ]
 }


### PR DESCRIPTION
Fixed `@UnionType` usage when abstract classes were involved.

Needed to infer class inheritance tree to use all field declarations when creating schema.

The solution based on [TypeORM 's decorator metadata handling](https://github.com/typeorm/typeorm/blob/de5cfe71c7c98c1c2689855378812a38cfc051fc/src/metadata-builder/MetadataUtils.ts) when using abstract classes for `@Entity` with their `@Column` decorator.