### PR TITLE
Bugfix - @After middleware changing return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Improved tests by adding @Root ones - [#52](https://github.com/indigotech/graphql-schema-decorator/pull/52) - [@babbarankit](https://github.com/babbarankit)
 - Added @InterfaceType decorator - [#46](https://github.com/indigotech/graphql-schema-decorator/pull/46) - [@felipesabino](https://github.com/felipesabino)
 - Added @After middleware decorator - [#56](https://github.com/indigotech/graphql-schema-decorator/pull/56) - [@marcelorisse](https://github.com/marcelorisse)
+- Bugfix - @After middleware changing return type - [#58](https://github.com/indigotech/graphql-schema-decorator/pull/58) - [@felipesabino](https://github.com/felipesabino)
 
 ### Breaking changes
 

--- a/src/type-factory/field.type-factory.ts
+++ b/src/type-factory/field.type-factory.ts
@@ -158,18 +158,22 @@ export function resolverFactory(
     }
 
     if (metadata.after) {
-      let next: (error?: Error) => void = (error?: Error, value?: any): any => {
-        if (error) {
-          throw error;
-        } else if (typeof (value) !== 'undefined') {
-          result = value;
-        }
-        return result;
-      };
-      metadata.after.middleware.call(fieldParentClass, context, args, result, next);
+      return new Promise((resolve, reject) => {
+        let next: (error?: Error) => void = (error?: Error, value?: any): any => {
+          if (error) {
+            reject(error);
+          } else if (typeof (value) !== 'undefined') {
+            resolve(value);
+          } else {
+            resolve(result);
+          }
+        };
+        metadata.after.middleware.call(fieldParentClass, context, args, result, next);
+      });
+    } else {
+      return result;
     }
 
-    return result;
   };
 
   return {


### PR DESCRIPTION
Fixing issue with `@After` middleware wrongly changing return type when different `@Field` types were involved