### PR TITLE
Allow circular references

### DIFF
--- a/src/specs/object.type-factory.spec.ts
+++ b/src/specs/object.type-factory.spec.ts
@@ -78,4 +78,14 @@ describe('objectTypeFactory', function () {
     assert(GQLType.name === 'Obj');
     assert((GQLType.getFields().circle.type as graphql.GraphQLObjectType).getFields().circle.type instanceof graphql.GraphQLObjectType);
   });
+
+  it('allows thunk circular dependecies', function () {
+    @D.ObjectType()
+    class A { @D.Field({type: () => B}) circle: any; } // tslint:disable-line:no-use-before-declare
+    @D.ObjectType()
+    class B { @D.Field({type: () => A}) circle: any; }
+    const GQLType = objectTypeFactory(A);
+    assert(GQLType.name === 'A');
+    assert((GQLType.getFields().circle.type as graphql.GraphQLObjectType).getFields().circle.type instanceof graphql.GraphQLObjectType);
+  });
 });

--- a/src/specs/object.type-factory.spec.ts
+++ b/src/specs/object.type-factory.spec.ts
@@ -36,8 +36,8 @@ describe('objectTypeFactory', function () {
     @D.ObjectType()
     class Obj { @D.Field() title: string; }
     const GQLType: any = objectTypeFactory(Obj);
-    assert(GQLType._typeConfig.name === 'Obj');
-    assert(GQLType._typeConfig.fields.title.type instanceof graphql.GraphQLScalarType);
+    assert(GQLType.name === 'Obj');
+    assert(GQLType.getFields().title.type instanceof graphql.GraphQLScalarType);
   });
 
   it('returns GraphQLInputObjectType with a class annotated by @InputObjectType', function () {
@@ -62,11 +62,20 @@ describe('objectTypeFactory', function () {
     @D.InputObjectType()
     class Obj { @D.Field() title: string; @D.Field({ type: undefined }) nested: {}; }
     try {
-      const GQLType: any = objectTypeFactory(Obj, true);
+      const GQLType = objectTypeFactory(Obj, true);
+      GQLType.getFields();
       assert.fail();
     } catch (e) {
       const err = e as SchemaFactoryError;
       assert(err.type === SchemaFactoryErrorType.NO_FIELD);
     }
+  });
+
+  it('returns GraphQLObjectType if includes circular references', function () {
+    @D.ObjectType()
+    class Obj { @D.Field() circle: Obj; }
+    const GQLType = objectTypeFactory(Obj);
+    assert(GQLType.name === 'Obj');
+    assert((GQLType.getFields().circle.type as graphql.GraphQLObjectType).getFields().circle.type instanceof graphql.GraphQLObjectType);
   });
 });

--- a/src/type-factory/field.type-factory.ts
+++ b/src/type-factory/field.type-factory.ts
@@ -44,7 +44,11 @@ function convertType(typeFn: Function, metadata: FieldMetadata | ArgumentMetadat
       returnType = objectTypeFactory(typeFn, isInput);
     }
   } else {
-    returnType = metadata.type;
+    try {
+      returnType = typeof metadata.type === 'function' ? metadata.type() : metadata.type;
+    } catch (e) {
+      returnType = metadata.type;
+    }
 
     if (returnType && returnType.prototype && getMetadataArgsStorage().filterUnionTypeByClass(returnType).length > 0) {
       returnType = unionTypeFactory(returnType, isInput);

--- a/src/type-factory/object.type-factory.ts
+++ b/src/type-factory/object.type-factory.ts
@@ -46,7 +46,7 @@ export function objectTypeFactory(target: Function, isInput: boolean = false): g
                 SchemaFactoryErrorType.NO_FIELD);
           }
 
-          const fields = fieldMetadataList.reduce((map, fieldMetadata) => {
+          const fields = () => fieldMetadataList.reduce((map, fieldMetadata) => {
             let field = fieldTypeFactory(fieldMetadata.target, fieldMetadata.field, isInput);
             if (!field) {
               throw new SchemaFactoryError(`@ObjectType()'s ${fieldMetadata.field.name} is annotated by @Field() but no type could be inferred`,


### PR DESCRIPTION
fix #64; fix #65 

It adds ability to specify type as a thunk as can be seen here: https://github.com/Cactucs/graphql-schema-decorator/blob/6ace1fb78883362ecfab87070a7a38c8b232daea/src/specs/object.type-factory.spec.ts#L84