### PR TITLE
Allowed circular dependencies

### DIFF
--- a/src/type-factory/field.type-factory.ts
+++ b/src/type-factory/field.type-factory.ts
@@ -44,7 +44,11 @@ function convertType(typeFn: Function, metadata: FieldMetadata | ArgumentMetadat
       returnType = objectTypeFactory(typeFn, isInput);
     }
   } else {
-    returnType = metadata.type;
+    try {
+      returnType = typeof metadata.type === 'function' ? metadata.type() : metadata.type;
+    } catch (e) {
+      returnType = metadata.type;
+    }
 
     if (returnType && returnType.prototype && getMetadataArgsStorage().filterUnionTypeByClass(returnType).length > 0) {
       returnType = unionTypeFactory(returnType, isInput);

--- a/src/type-factory/object.type-factory.ts
+++ b/src/type-factory/object.type-factory.ts
@@ -46,7 +46,7 @@ export function objectTypeFactory(target: Function, isInput: boolean = false): g
                 SchemaFactoryErrorType.NO_FIELD);
           }
 
-          const fields = fieldMetadataList.reduce((map, fieldMetadata) => {
+          const fields = () => fieldMetadataList.reduce((map, fieldMetadata) => {
             let field = fieldTypeFactory(fieldMetadata.target, fieldMetadata.field, isInput);
             if (!field) {
               throw new SchemaFactoryError(`@ObjectType()'s ${fieldMetadata.field.name} is annotated by @Field() but no type could be inferred`,


### PR DESCRIPTION
Introducing circular dependencies.

```
@ObjectType()
class A {
  @Field({type: () => B}) b: any; // note that thunk - `() => B` is now required in case of circular references istead of just `{type: B}`
}

@ObjectType()
class B {
  @Field({type: () => A}) a: any; 
}
```

Read more: https://github.com/graphql/graphql-js/issues/373

Here is original approach I've got idea from: https://github.com/Cactucs/graphql-schema-decorator/commit/6ace1fb78883362ecfab87070a7a38c8b232daea