### PR TITLE
Use float instead of int for :number type

### DIFF
--- a/src/type-factory/field.type-factory.ts
+++ b/src/type-factory/field.type-factory.ts
@@ -34,7 +34,7 @@ function convertType(typeFn: Function, metadata: FieldMetadata | ArgumentMetadat
 
   if (!metadata.type) {
     if (typeFn === Number) {
-      returnType = graphql.GraphQLInt;     // FIXME or float?
+      returnType = graphql.GraphQLFloat;
     } else if (typeFn === String) {
       returnType = graphql.GraphQLString;
     } else if (typeFn === Boolean) {


### PR DESCRIPTION
In case you'd use `:number` type of some field in typescript, right now, resulting schema would give this field `Int` type. 

While `int` is propably more popular than `float` it might cause some data accuracy lose without any warning. 

Right now, if you'd like to use Int, you'd have to explicitly set it as `type` property of decorator